### PR TITLE
Enable Quiet Hours Feature

### DIFF
--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -121,7 +121,11 @@ export default function SettingsScreen() {
           icon="notifications-outline"
           onPress={() => router.push('/settings/notifications')}
         />
-        <SettingsRow label="Quiet Hours" icon="moon-outline" badge="Soon" disabled />
+        <SettingsRow
+          label="Quiet Hours"
+          icon="moon-outline"
+          onPress={() => router.push('/settings/quiet-hours')}
+        />
       </View>
 
       {/* Integrations Section */}

--- a/app/settings/quiet-hours.tsx
+++ b/app/settings/quiet-hours.tsx
@@ -126,8 +126,8 @@ export default function QuietHoursSettingsScreen() {
   return (
     <ScrollView style={styles.container}>
       <Text style={styles.description}>
-        Set quiet hours to pause notifications during specific times. You&apos;ll still receive
-        notifications for blocking alerts.
+        Set quiet hours to silence all notifications during specific times. You can review any
+        missed notifications after quiet hours end.
       </Text>
 
       <View style={styles.section}>
@@ -180,10 +180,11 @@ export default function QuietHoursSettingsScreen() {
       {quietHours.enabled && (
         <View style={styles.info}>
           <Text style={styles.infoText}>
-            Notifications will be silenced from {quietHours.start} to {quietHours.end} every day.
+            All notifications will be silenced from {quietHours.start} to {quietHours.end} every
+            day.
           </Text>
           <Text style={styles.infoText}>
-            Blocking alerts that require immediate attention will still be shown.
+            You can review any missed notifications after quiet hours end.
           </Text>
         </View>
       )}


### PR DESCRIPTION
## Summary

Enable the fully-implemented but disabled Quiet Hours feature and update all messaging to clarify that **ALL notifications are silenced** during quiet hours (no exceptions).

## Changes Made

### 1. Enable Navigation (`app/settings/index.tsx`)
**Before:**
```tsx
<SettingsRow label="Quiet Hours" icon="moon-outline" badge="Soon" disabled />
```

**After:**
```tsx
<SettingsRow
  label="Quiet Hours"
  icon="moon-outline"
  onPress={() => router.push('/settings/quiet-hours')}
/>
```

### 2. Update Quiet Hours Screen (`app/settings/quiet-hours.tsx`)

**Description updated:**
- ❌ "You'll still receive notifications for blocking alerts"
- ✅ "Set quiet hours to silence **all notifications** during specific times"

**Info messages updated:**
- ❌ "Blocking alerts that require immediate attention will still be shown"
- ✅ "**All notifications** will be silenced from [start] to [end] every day"
- ✅ "You can review any missed notifications after quiet hours end"

## Feature Details

The Quiet Hours feature was fully implemented in Phase 8 but left disabled. This PR simply enables it and removes confusing exception messaging.

**When quiet hours is enabled:**
- ALL notification types are silenced (no exceptions)
- No pop-ups, banners, or alerts during configured time window
- Users can set custom start/end times with 24-hour format (e.g., 22:00 to 08:00)
- Settings sync to local storage and API automatically
- Optimistic UI updates with error handling

## Testing

- [ ] Navigate to Settings → Notifications → Quiet Hours
- [ ] Enable quiet hours toggle
- [ ] Set start and end times
- [ ] Verify settings persist after app restart
- [ ] Verify messaging clearly states ALL notifications are silenced

## Files Changed

- `app/settings/index.tsx` - Enable navigation, remove "Soon" badge
- `app/settings/quiet-hours.tsx` - Remove exception messaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)