### PR TITLE
Fix package-lock.json sync issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "acp-mobile",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "acp-mobile",
-      "version": "1.0.0",
+      "version": "0.0.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "^2.2.0",
@@ -40,6 +40,7 @@
         "react-native": "0.81.5",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-get-random-values": "~1.11.0",
+        "react-native-gifted-charts": "^1.4.52",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
@@ -9597,6 +9598,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/gifted-charts-core": {
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/gifted-charts-core/-/gifted-charts-core-0.1.72.tgz",
+      "integrity": "sha512-ID98gSvYA/6Egg/SxjjVAnFMpK0c4H9NZKkF4vRWtvJOioWegEGlQKN7BcQhuyKHr/HPmz7kGID3XJUuoM7UTQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-svg": "*"
+      }
+    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -14697,6 +14709,30 @@
       },
       "peerDependencies": {
         "react-native": ">=0.56"
+      }
+    },
+    "node_modules/react-native-gifted-charts": {
+      "version": "1.4.70",
+      "resolved": "https://registry.npmjs.org/react-native-gifted-charts/-/react-native-gifted-charts-1.4.70.tgz",
+      "integrity": "sha512-nsbth3aMeMwu40ZNAn512TGZLks5Untplby5ABSe22+FLUdXYkdCzeR5/CodL6gxCcpsqQYXgAVvtujZnDRErA==",
+      "license": "MIT",
+      "dependencies": {
+        "gifted-charts-core": "0.1.72"
+      },
+      "peerDependencies": {
+        "expo-linear-gradient": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-linear-gradient": "*",
+        "react-native-svg": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo-linear-gradient": {
+          "optional": true
+        },
+        "react-native-linear-gradient": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-is-edge-to-edge": {


### PR DESCRIPTION
## Summary

Fixes the CI failure caused by package-lock.json being out of sync with package.json.

## Problem

The CI workflow was failing with:
```
npm error `npm ci` can only install packages when your package.json and 
package-lock.json or npm-shrinkwrap.json are in sync.

npm error Missing: react-native-gifted-charts@1.4.70 from lock file
npm error Missing: gifted-charts-core@0.1.72 from lock file
```

## Solution

Ran `npm install` to regenerate package-lock.json with the correct dependency tree that matches package.json.

### Changes
- Updated package-lock.json to include:
  - `react-native-gifted-charts@1.4.70`
  - `gifted-charts-core@0.1.72` (peer dependency)
- Fixed version mismatch (1.0.0 → 0.0.0 to match package.json)

## Test Plan

- [x] `npm install` completed successfully
- [x] Pre-commit hooks passed
- [ ] CI workflow will validate on this PR

## Breaking Changes

None - this is a lock file sync fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)